### PR TITLE
edit serialport default constructor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,22 @@
         "xutility": "cpp",
         "*.tcc": "cpp",
         "memory_resource": "cpp",
-        "cinttypes": "cpp"
+        "cinttypes": "cpp",
+        "compare": "cpp",
+        "complex": "cpp",
+        "csignal": "cpp",
+        "forward_list": "cpp",
+        "iomanip": "cpp",
+        "locale": "cpp",
+        "optional": "cpp",
+        "regex": "cpp",
+        "set": "cpp",
+        "unordered_set": "cpp",
+        "valarray": "cpp",
+        "variant": "cpp",
+        "xlocbuf": "cpp",
+        "xlocmes": "cpp",
+        "xlocmon": "cpp",
+        "xloctime": "cpp"
     }
 }

--- a/examples/ex_serial.cpp
+++ b/examples/ex_serial.cpp
@@ -8,11 +8,11 @@ using namespace mahi::com;
 
 int main() {
 
-    SerialPort comm4(3, 9600);
-    SerialPort comm5(4, 9600);
+    SerialPort comm4;
+    SerialPort comm5;
 
-    comm4.open();
-    comm5.open();
+    comm4.open(3, 9600);
+    comm5.open(4, 9600);
 
     unsigned char send[5] = "abcd";
 

--- a/include/Mahi/Com/SerialPort.hpp
+++ b/include/Mahi/Com/SerialPort.hpp
@@ -29,14 +29,14 @@ namespace com {
 class SerialPort : util::NonCopyable {
 public:
 
-    /// Constructor
-    SerialPort(std::size_t port, std::size_t baudrate = 9600, std::string mode = "8N1");
+    /// Default constructor. Creates an empty (invalid) serialport
+    SerialPort();
 
     /// Destructor
     ~SerialPort();
 
     /// Opens communication on specified port
-    bool open();
+    bool open(std::size_t port, std::size_t baudrate = 9600, std::string mode = "8N1");
 
     /// Closes communication on specified port
     bool close();

--- a/src/Mahi/Com/SerialPort.cpp
+++ b/src/Mahi/Com/SerialPort.cpp
@@ -7,13 +7,9 @@ using namespace mahi::util;
 namespace mahi {
 namespace com {
 
-SerialPort::SerialPort(std::size_t port, std::size_t baudrate, std::string mode) :
-    is_open_(false),
-    port_(port),
-    baudrate_(baudrate),
-    mode_(mode)
+SerialPort::SerialPort() :  
+    is_open_(false) 
 {
-
 }
 
 SerialPort::~SerialPort() {
@@ -21,7 +17,11 @@ SerialPort::~SerialPort() {
         close();
 }
 
-bool SerialPort::open() {
+bool SerialPort::open(std::size_t port, std::size_t baudrate, std::string mode) {
+    port_= port;
+    baudrate_ = baudrate;
+    mode_ = mode;
+
     if (is_open())
         close();
     if (RS232_OpenComport(static_cast<int>(port_), static_cast<int>(baudrate_), mode_.c_str()) == 1)
@@ -63,8 +63,6 @@ bool SerialPort::close() {
 bool SerialPort::is_open() const {
     return is_open_;
 }
-
-
 
 } // namespace mahi
 } // namespace com


### PR DESCRIPTION
Created empty default constructor and added member variable information to `open` method